### PR TITLE
187 - fix: cumulative contributions on the chart

### DIFF
--- a/src/pages/Contributions/TopContributors/index.tsx
+++ b/src/pages/Contributions/TopContributors/index.tsx
@@ -5,7 +5,7 @@ import SectionHeading from 'components/SectionHeading';
 import {Card} from 'styles/components/CardStyle';
 import {ContributionCard, ContributionCardHeader} from 'components/Contributions/ContributionCard';
 import {ContributorInfo} from 'components/Contributions/ContributorInfo';
-import {getTopContributors} from 'utils/contributors';
+import {getTopContributors} from 'utils/contributions';
 import {Contribution, Contributor} from 'types';
 import * as S from './Styles';
 

--- a/src/pages/Contributions/TotalContributionsChart/index.tsx
+++ b/src/pages/Contributions/TotalContributionsChart/index.tsx
@@ -1,6 +1,7 @@
 import {CartesianGrid, AreaChart, Area, ResponsiveContainer, Tooltip, XAxis, YAxis} from 'recharts';
 
 import SectionHeading from 'components/SectionHeading';
+import {getCumulativeContributions} from 'utils/contributions';
 import {SFC} from 'types';
 import {Card} from 'styles/components/CardStyle';
 
@@ -10,6 +11,8 @@ interface TotalContributionsChartProps {
 }
 
 const TotalContributionsChart: SFC<TotalContributionsChartProps> = ({className, contributions}) => {
+  const cumulativeContributions = getCumulativeContributions(contributions);
+
   const formatDate = (date: string) => {
     const newDate = new Date(date);
     return `${newDate.getDate()}/${newDate.getMonth() + 1}`;
@@ -28,12 +31,12 @@ const TotalContributionsChart: SFC<TotalContributionsChartProps> = ({className, 
       <SectionHeading heading="Total Contributions" />
       <Card>
         <ResponsiveContainer height={380} width="100%">
-          <AreaChart data={contributions}>
+          <AreaChart data={cumulativeContributions}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="created_date" tick={<CustomAxisTick />} />
-            <YAxis dataKey="reward_amount" />
+            <YAxis dataKey="total_rewards" />
             <Tooltip />
-            <Area type="monotone" dataKey="reward_amount" stroke="#82ca9d" fill="#82ca9d" />
+            <Area type="monotone" dataKey="total_rewards" stroke="#82ca9d" fill="#82ca9d" />
           </AreaChart>
         </ResponsiveContainer>
       </Card>

--- a/src/utils/contributions.ts
+++ b/src/utils/contributions.ts
@@ -52,3 +52,20 @@ export const getTopContributors = (contributions: Contribution[]): Contributor[]
       positionIcon: getPositionIcon(index + 1),
     }));
 };
+
+/**
+ * Computes cumulative reward amounts for a list of contributions.
+ * Contributions are sorted by the creation date, and each entry is appended with a cumulative reward total.
+ */
+export const getCumulativeContributions = (contributions: any[]): any[] => {
+  let cumulativeTotal = 0;
+  return contributions
+    .sort((a, b) => new Date(a.created_date).getTime() - new Date(b.created_date).getTime())
+    .map((contribution) => {
+      cumulativeTotal += contribution.reward_amount;
+      return {
+        ...contribution,
+        total_rewards: cumulativeTotal, // Append cumulative reward to each contribution
+      };
+    });
+};


### PR DESCRIPTION
closes #187

Screenshot:

<img width="1440" alt="image" src="https://github.com/thenewboston-developers/thenewboston-Frontend/assets/52558124/a4b7d826-e92d-464c-a5de-f349852b7234">

<img width="827" alt="image" src="https://github.com/thenewboston-developers/thenewboston-Frontend/assets/52558124/d09f6a49-1a35-4de7-ab35-4a37b6257007">
