### PR TITLE
improve error message when account creation fix

### DIFF
--- a/src/layouts/Unauthenticated/forms/CreateAccountForm.tsx
+++ b/src/layouts/Unauthenticated/forms/CreateAccountForm.tsx
@@ -9,7 +9,6 @@ import {AppDispatch, SFC} from 'types';
 import {displayErrorToast} from 'utils/toasts';
 import yup from 'utils/yup';
 import * as S from './Styles';
-
 const CreateAccountForm: SFC = () => {
   const dispatch = useDispatch<AppDispatch>();
   const navigate = useNavigate();
@@ -33,8 +32,24 @@ const CreateAccountForm: SFC = () => {
       const user = await dispatch(createUser(requestData));
       navigate(`/profile/${user.id}`);
     } catch (error) {
-      console.error(error);
-      displayErrorToast('Error creating account');
+      let errorMessage = 'Error creating account';
+      if (typeof error === 'object' && error !== null) {
+        if ('response' in error) {
+          const axiosError = error as {response: {data: {message?: string; error?: string}; status: number}};
+          const errorData = axiosError.response.data;
+          const errorStatus = axiosError.response.status;
+          if (errorData) {
+            if (errorStatus === 500) {
+              errorMessage = 'Server error, please try again later';
+            } else {
+              errorMessage = Object.values(errorData)[0] as string;
+            }
+          }
+        } else {
+          errorMessage = 'Network error, please try again later';
+        }
+      }
+      displayErrorToast(errorMessage);
     }
   };
 

--- a/src/layouts/Unauthenticated/forms/CreateAccountForm.tsx
+++ b/src/layouts/Unauthenticated/forms/CreateAccountForm.tsx
@@ -9,6 +9,7 @@ import {AppDispatch, SFC} from 'types';
 import {displayErrorToast} from 'utils/toasts';
 import yup from 'utils/yup';
 import * as S from './Styles';
+
 const CreateAccountForm: SFC = () => {
   const dispatch = useDispatch<AppDispatch>();
   const navigate = useNavigate();
@@ -31,25 +32,9 @@ const CreateAccountForm: SFC = () => {
       };
       const user = await dispatch(createUser(requestData));
       navigate(`/profile/${user.id}`);
-    } catch (error) {
-      let errorMessage = 'Error creating account';
-      if (typeof error === 'object' && error !== null) {
-        if ('response' in error) {
-          const axiosError = error as {response: {data: {message?: string; error?: string}; status: number}};
-          const errorData = axiosError.response.data;
-          const errorStatus = axiosError.response.status;
-          if (errorData) {
-            if (errorStatus === 500) {
-              errorMessage = 'Server error, please try again later';
-            } else {
-              errorMessage = Object.values(errorData)[0] as string;
-            }
-          }
-        } else {
-          errorMessage = 'Network error, please try again later';
-        }
-      }
-      displayErrorToast(errorMessage);
+    } catch (error: any) {
+      console.error(error);
+      displayErrorToast(error);
     }
   };
 


### PR DESCRIPTION

Improved the toaster to give appropriate custom messages based on the response from the back-end. 

- For instance, if the backend gives a status of 500, it tells the user, "Server error, please try again later." 
- In case the invitation code is invalid, it responds, "Invalid invitation code."
