### PR TITLE
391 - Background doesn’t blur on image expand

### DIFF
--- a/src/modals/FullScreenImageModal/Styles.ts
+++ b/src/modals/FullScreenImageModal/Styles.ts
@@ -2,7 +2,7 @@ import styled, {keyframes} from 'styled-components';
 
 import UImagePreview from 'components/ImagePreview';
 
-import {colors} from 'styles';
+import {breakpoints, colors} from 'styles';
 
 const addOverlay = keyframes`
   from {
@@ -43,6 +43,14 @@ export const ImagePreviewContainer = styled.div`
   img {
     max-height: 600px;
     max-width: 700px;
+    @media (max-width: ${breakpoints.mini}) {
+      max-height: 400px;
+      max-width: 350px;
+    }
+    @media (min-width: ${breakpoints.mini}) and (max-width: ${breakpoints.mobile}) {
+      max-height: 500px;
+      max-width: 480px;
+    }
   }
 `;
 

--- a/src/modals/FullScreenImageModal/Styles.ts
+++ b/src/modals/FullScreenImageModal/Styles.ts
@@ -57,6 +57,7 @@ export const ImagePreviewContainer = styled.div`
 export const ImagePreview = styled(UImagePreview)`
   align-items: center;
   backdrop-filter: blur(80px);
+  -webkit-backdrop-filter: blur(80px); /* webkit prefix for Safari */
   display: flex;
   height: 100vh;
   justify-content: center;


### PR DESCRIPTION
Closes #391 
Mobile Device
![image](https://github.com/thenewboston-developers/thenewboston-Frontend/assets/77836546/becd135b-e339-4afe-90b2-683631953918)

Tablet Device
![image](https://github.com/thenewboston-developers/thenewboston-Frontend/assets/77836546/d34521fc-9ade-438d-bee7-796fc7e6d21f)

Laptop Device
![image](https://github.com/thenewboston-developers/thenewboston-Frontend/assets/77836546/51a29f18-6127-4111-a719-10e871470dc7)
