### PR TITLE
242 - redux version introduced + migrations setup for future use

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,4 +1,14 @@
-import {FLUSH, PAUSE, PERSIST, persistReducer, persistStore, PURGE, REGISTER, REHYDRATE} from 'redux-persist';
+import {
+  FLUSH,
+  PAUSE,
+  PERSIST,
+  PURGE,
+  REGISTER,
+  REHYDRATE,
+  createMigrate,
+  persistReducer,
+  persistStore,
+} from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
 import {AnyAction, combineReducers, configureStore} from '@reduxjs/toolkit';
 
@@ -25,6 +35,7 @@ import invitationsReducer from 'store/invitations';
 import lecturesReducer from 'store/lectures';
 import managerReducer from 'store/manager';
 import messagesReducer from 'store/messages';
+import migrations from 'store/migrations';
 import notificationsReducer from 'store/notifications';
 import ordersReducer from 'store/orders';
 import postsReducer from 'store/posts';
@@ -78,7 +89,9 @@ const appReducer = (state: any, action: AnyAction) => {
 
 const persistConfig = {
   key: 'thenewboston',
+  migrate: createMigrate(migrations, {debug: false}),
   storage,
+  version: 1,
 };
 
 const persistedReducer = persistReducer(persistConfig, appReducer);

--- a/src/store/migrations/index.ts
+++ b/src/store/migrations/index.ts
@@ -1,0 +1,3 @@
+const migrations = {};
+
+export default migrations;


### PR DESCRIPTION
Closes #242

Note: This PR doesn't really fix the white page bug. 
it just introduced the redux version and initial migrations (empty) setup for future use. (if needed)

ps: For current users, we created a logout URL with which users can get logged out and login again which would reset their redux structure 

<img width="691" alt="image" src="https://github.com/thenewboston-developers/thenewboston-Frontend/assets/52558124/8e0b5961-b5af-42af-9ea6-6ab8ae2227fa">

<img width="676" alt="image" src="https://github.com/thenewboston-developers/thenewboston-Frontend/assets/52558124/5238be01-8e65-4548-bb76-8998ad7d67f1">
