### PR TITLE
fix: artwork modal styling

### DIFF
--- a/src/modals/ArtworkModal/Styles.ts
+++ b/src/modals/ArtworkModal/Styles.ts
@@ -1,26 +1,26 @@
 import styled from 'styled-components';
 
-import UTab from 'components/Tab';
 import UModal from 'components/Modal';
+import UTab from 'components/Tab';
 import UTabs from 'components/Tabs';
+
+import {breakpoints} from 'styles';
+
+export const Container = styled.div``;
+
+export const Divider = styled.div`
+  height: 3vh;
+`;
 
 export const Modal = styled(UModal)`
   display: flex;
   flex-direction: column;
-  width: 519px;
-`;
-export const Wrap = styled.div`
-  font-weight: bold;
-`;
+  max-width: 520px;
+  width: 80%;
 
-export const Tabs = styled(UTabs)`
-  font-weight: bold;
-  height: 6vh;
-  width: 23vw;
-`;
-
-export const Divider = styled.div`
-  height: 3vh;
+  @media (max-width: ${breakpoints.mini}) {
+    width: 90%;
+  }
 `;
 
 export const Row = styled.div`
@@ -28,8 +28,11 @@ export const Row = styled.div`
   gap: 1vw;
   grid-template-columns: repeat(2, 1fr);
 `;
-export const Container = styled.div``;
 
 export const Tab = styled(UTab)`
-  font-size: 0.8vw;
+  font-size: 0.8em;
+`;
+
+export const Tabs = styled(UTabs)`
+  font-weight: bold;
 `;


### PR DESCRIPTION
Closes #419 

<img width="524" alt="image" src="https://github.com/user-attachments/assets/b99eda33-b796-4a5d-a0c6-52e157a24638">

<img width="954" alt="image" src="https://github.com/user-attachments/assets/e8fb14c0-c7e5-4f27-bee4-dfc07b6d30b5">

<img width="381" alt="image" src="https://github.com/user-attachments/assets/df7b7d09-4f3e-41a3-843d-54ec2af5e282">

<img width="260" alt="image" src="https://github.com/user-attachments/assets/42dc6d61-04e0-4cd0-8b4f-23a9e9e35c7e">
