### PR TITLE
removed unused dispatcher from authenticated wrapper

### DIFF
--- a/src/layouts/Authenticated/index.tsx
+++ b/src/layouts/Authenticated/index.tsx
@@ -2,7 +2,6 @@ import {useEffect} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {useLocation} from 'react-router-dom';
 
-import {getAssetPairs} from 'dispatchers/assetPairs';
 import {checkForDeploymentUpdate} from 'dispatchers/frontendDeployments';
 import {getNotifications} from 'dispatchers/notifications';
 import {useIsMobile} from 'hooks';
@@ -29,11 +28,7 @@ const Authenticated: SFC = ({className}) => {
   useEffect(() => {
     (async () => {
       try {
-        await Promise.all([
-          dispatch(checkForDeploymentUpdate()),
-          dispatch(getAssetPairs()),
-          dispatch(getNotifications()),
-        ]);
+        await Promise.all([dispatch(checkForDeploymentUpdate()), dispatch(getNotifications())]);
       } catch (error) {
         displayErrorToast('Error fetching initial data');
       }


### PR DESCRIPTION
Key Findings:

Trade component loads its own data - The Exchange/Trade component at /src/pages/Exchange/MainArea/Trade/index.tsx:33 already calls dispatch(_getAssetPairs())
when it mounts, so it handles loading asset pairs independently.
Limited usage scope - Asset pairs are only used in:
- Trade page - Loads its own data
- AssetPairSelector - Just reads from Redux store (loaded by Trade)
- CurrencyInfoSection - Makes direct API calls, doesn't use Redux store
No other components affected - The Exchange Home page doesn't use asset pairs from Redux, and there are no other components that depend on having this data preloaded.
Performance benefit - By removing it from the authenticated wrapper, we can avoid loading asset pairs for users who never visit the exchange section, improving initial load performance.
The removal won't cause any issues since the Trade component responsibly loads its own required data when needed.