### PR TITLE
Implement paginated asset pair fetching and selection modal

### DIFF
--- a/src/api/assetPairs.ts
+++ b/src/api/assetPairs.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import {AssetPair} from 'types';
+import {AssetPair, PaginatedResponse} from 'types';
 import {authorizationHeaders} from 'utils/authentication';
 
 const BASE_URL = `${process.env.REACT_APP_API_URL}/api/asset-pairs`;
@@ -8,9 +8,11 @@ const BASE_URL = `${process.env.REACT_APP_API_URL}/api/asset-pairs`;
 export const getAssetPairs = async (params?: {
   primary_currency_ticker?: string;
   secondary_currency_ticker?: string;
-}): Promise<AssetPair[]> => {
+  page?: number;
+  page_size?: number;
+}): Promise<PaginatedResponse<AssetPair>> => {
   try {
-    const response = await axios.get<AssetPair[]>(BASE_URL, {
+    const response = await axios.get<PaginatedResponse<AssetPair>>(BASE_URL, {
       ...authorizationHeaders(),
       params,
     });

--- a/src/dispatchers/assetPairs.ts
+++ b/src/dispatchers/assetPairs.ts
@@ -2,7 +2,8 @@ import {getAssetPairs as _getAssetPairs} from 'api/assetPairs';
 import {setAssetPairs} from 'store/assetPairs';
 import {AppDispatch} from 'types';
 
-export const getAssetPairs = () => async (dispatch: AppDispatch) => {
-  const responseData = await _getAssetPairs();
-  dispatch(setAssetPairs(responseData));
+export const getAssetPairs = (params?: {page?: number; page_size?: number}) => async (dispatch: AppDispatch) => {
+  const responseData = await _getAssetPairs(params);
+  dispatch(setAssetPairs(responseData.results));
+  return responseData;
 };

--- a/src/modals/AssetPairSelectModal/Styles.ts
+++ b/src/modals/AssetPairSelectModal/Styles.ts
@@ -1,0 +1,35 @@
+import styled from 'styled-components';
+
+import UModal from 'components/Modal';
+import UPagination from 'components/Pagination';
+import {breakpoints, hiddenScroll, radioCardContainerPadding} from 'styles';
+
+export const Modal = styled(UModal)`
+  max-height: 80vh;
+  width: 680px;
+
+  @media (max-width: ${breakpoints.mobile}) {
+    width: 95%;
+  }
+`;
+
+export const Pagination = styled(UPagination)`
+  margin-top: 24px;
+`;
+
+export const RadioCardContainer = styled.div`
+  ${hiddenScroll};
+  ${radioCardContainerPadding};
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(3, 1fr);
+  max-height: calc(80vh - 200px);
+
+  @media (max-width: ${breakpoints.mobile}) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media (max-width: ${breakpoints.mini}) {
+    grid-template-columns: 1fr;
+  }
+`;

--- a/src/modals/AssetPairSelectModal/index.tsx
+++ b/src/modals/AssetPairSelectModal/index.tsx
@@ -1,0 +1,105 @@
+import {useEffect, useState} from 'react';
+
+import {getAssetPairs} from 'api/assetPairs';
+import EmptyText from 'components/EmptyText';
+import Loader from 'components/Loader';
+import {ModalBody} from 'components/Modal';
+import RadioCard from 'components/RadioCard';
+import {ToastType} from 'enums';
+import {AssetPair, PaginatedResponse, SFC} from 'types';
+import {displayErrorToast, displayToast} from 'utils/toasts';
+
+import * as S from './Styles';
+
+export interface AssetPairSelectModalProps {
+  close(): void;
+  activeAssetPair: AssetPair | null;
+  handleChange(assetPairId: string): void;
+}
+
+const AssetPairSelectModal: SFC<AssetPairSelectModalProps> = ({className, close, activeAssetPair, handleChange}) => {
+  const [animationType, setAnimationType] = useState<'select' | 'deselect' | null>(null);
+  const [assetPairsData, setAssetPairsData] = useState<PaginatedResponse<AssetPair> | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const pageSize = 12;
+
+  useEffect(() => {
+    (async () => {
+      setIsLoading(true);
+      try {
+        const data = await getAssetPairs({page: currentPage, page_size: pageSize});
+        setAssetPairsData(data);
+      } catch (error) {
+        displayErrorToast('Error fetching asset pairs');
+        setAssetPairsData(null);
+      } finally {
+        setIsLoading(false);
+      }
+    })();
+  }, [currentPage]);
+
+  const handleAnimationComplete = () => {
+    if (animationType === 'select') {
+      // For selection, wait to complete 1 second total
+      setTimeout(() => {
+        close();
+      }, 500);
+    } else if (animationType === 'deselect') {
+      // For deselection, close faster (0.2s animation + 0.3s delay = 0.5s total)
+      setTimeout(() => {
+        close();
+      }, 300);
+    }
+    setAnimationType(null);
+  };
+
+  const handleAssetPairClick = (assetPair: AssetPair) => {
+    setAnimationType('select');
+    displayToast(`${assetPair.primary_currency.ticker} selected`, ToastType.SUCCESS);
+    handleChange(assetPair.id.toString());
+  };
+
+  const handlePageChange = (page: number) => {
+    if (page !== currentPage) {
+      setCurrentPage(page);
+    }
+  };
+
+  const renderContent = () => {
+    if (isLoading) return <Loader />;
+    if (!assetPairsData || !assetPairsData.results.length) return <EmptyText>No asset pairs available</EmptyText>;
+
+    return (
+      <>
+        <S.RadioCardContainer>
+          {assetPairsData.results.map((_assetPair) => {
+            return (
+              <RadioCard
+                currency={_assetPair.primary_currency}
+                isSelected={activeAssetPair?.id === _assetPair.id}
+                key={_assetPair.id}
+                onAnimationComplete={handleAnimationComplete}
+                onClick={() => handleAssetPairClick(_assetPair)}
+              />
+            );
+          })}
+        </S.RadioCardContainer>
+        <S.Pagination
+          currentPage={currentPage}
+          onPageChange={handlePageChange}
+          totalPages={Math.ceil(assetPairsData.count / pageSize)}
+        />
+      </>
+    );
+  };
+
+  return (
+    <S.Modal className={className} close={close} header="Asset Pairs">
+      <ModalBody>{renderContent()}</ModalBody>
+    </S.Modal>
+  );
+};
+
+export default AssetPairSelectModal;

--- a/src/pages/Currencies/Detail/CurrencyInfoSection/index.tsx
+++ b/src/pages/Currencies/Detail/CurrencyInfoSection/index.tsx
@@ -47,8 +47,8 @@ const CurrencyInfoSection: SFC<CurrencyInfoSectionProps> = ({
           secondary_currency_ticker: DEFAULT_CURRENCY_TICKER,
         });
 
-        if (assetPairs.length > 0) {
-          setAssetPairId(assetPairs[0].id);
+        if (assetPairs.count > 0) {
+          setAssetPairId(assetPairs.results[0].id);
         }
       } catch (error) {
         displayErrorToast('Error fetching asset pair');

--- a/src/pages/Exchange/MainArea/Trade/OrderTools/AssetPairSelector/index.tsx
+++ b/src/pages/Exchange/MainArea/Trade/OrderTools/AssetPairSelector/index.tsx
@@ -1,8 +1,7 @@
-import {ChangeEvent} from 'react';
-import {useSelector} from 'react-redux';
-import {useNavigate, useParams} from 'react-router-dom';
+import {useState} from 'react';
+import {useNavigate} from 'react-router-dom';
 
-import {getAssetPairs} from 'selectors/state';
+import AssetPairSelectModal from 'modals/AssetPairSelectModal';
 import {AssetPair, SFC} from 'types';
 
 import * as S from './Styles';
@@ -12,33 +11,29 @@ interface AssetPairSelectorProps {
 }
 
 const AssetPairSelector: SFC<AssetPairSelectorProps> = ({activeAssetPair, className}) => {
-  const assetPairs = useSelector(getAssetPairs);
   const navigate = useNavigate();
-  const {assetPairId} = useParams<{assetPairId: string}>();
-  const updatedAssetPairs = Object.entries(assetPairs);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-  const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
-    const newAssetPairId = e.target.value;
+  const handleChange = (newAssetPairId: string) => {
+    setIsMenuOpen(false);
     navigate(`/exchange/trade/${newAssetPairId}`);
+  };
+
+  const toggleMenu = () => {
+    setIsMenuOpen(!isMenuOpen);
   };
 
   return (
     <S.Container className={className}>
-      <S.Content>
+      <S.Content onClick={toggleMenu}>
         <S.ImageContainer>
           <S.Image src={activeAssetPair?.primary_currency.logo} />
         </S.ImageContainer>
         <S.Ticker>{activeAssetPair?.primary_currency.ticker}</S.Ticker>
       </S.Content>
-      <S.Select id="asset-pair-selector" name="asset-pair-selector" onChange={handleChange} value={assetPairId || ''}>
-        {updatedAssetPairs.map((assetsValue, index) => {
-          return (
-            <option key={index} value={assetsValue[1].id}>
-              {assetsValue[1].primary_currency.ticker}
-            </option>
-          );
-        })}
-      </S.Select>
+      {isMenuOpen ? (
+        <AssetPairSelectModal activeAssetPair={activeAssetPair} close={toggleMenu} handleChange={handleChange} />
+      ) : null}
     </S.Container>
   );
 };


### PR DESCRIPTION
- Updated `getAssetPairs` API function to support pagination.
- Created `AssetPairSelectModal` for selecting asset pairs with pagination.
- Modified `CurrencyInfoSection` and `AssetPairSelector` components to handle new data structure.
- Added styles for the new modal and pagination components.


closes #866 