### PR TITLE
Fix wallet list ordering to handle potential null values in wallets

### DIFF
--- a/src/pages/Wallets/Home/index.tsx
+++ b/src/pages/Wallets/Home/index.tsx
@@ -35,7 +35,10 @@ const Home: SFC = ({className}) => {
   const dispatch = useDispatch<AppDispatch>();
   const manager = useSelector(getManager);
   const wallets = useSelector(getWallets);
-  const walletList = useMemo(() => orderBy(Object.values(wallets), [(wallet) => wallet.currency.ticker]), [wallets]);
+  const walletList = useMemo(
+    () => orderBy(Object.values(wallets || {}), [(wallet) => wallet.currency.ticker]),
+    [wallets],
+  );
   const {activeWallet} = manager;
 
   useEffect(() => {


### PR DESCRIPTION
The error was occurring because wallets was undefined or null when the component first renders. By adding wallets || {}, we ensure that Object.values() always receives a valid object, defaulting to an empty object when wallets is falsy. This will return an empty array in that case, which orderBy can handle safely.


Closes: #868 