### PR TITLE
Add asset pair fetching by ID and update dispatchers and store

### DIFF
--- a/src/api/assetPairs.ts
+++ b/src/api/assetPairs.ts
@@ -5,6 +5,15 @@ import {authorizationHeaders} from 'utils/authentication';
 
 const BASE_URL = `${process.env.REACT_APP_API_URL}/api/asset-pairs`;
 
+export const getAssetPairById = async (id: number): Promise<AssetPair> => {
+  try {
+    const response = await axios.get<AssetPair>(`${BASE_URL}/${id}`, authorizationHeaders());
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};
+
 export const getAssetPairs = async (params?: {
   primary_currency_ticker?: string;
   secondary_currency_ticker?: string;

--- a/src/dispatchers/assetPairs.ts
+++ b/src/dispatchers/assetPairs.ts
@@ -1,6 +1,12 @@
-import {getAssetPairs as _getAssetPairs} from 'api/assetPairs';
-import {setAssetPairs} from 'store/assetPairs';
+import {getAssetPairById as _getAssetPairById, getAssetPairs as _getAssetPairs} from 'api/assetPairs';
+import {setAssetPair, setAssetPairs} from 'store/assetPairs';
 import {AppDispatch} from 'types';
+
+export const getAssetPairById = (id: number) => async (dispatch: AppDispatch) => {
+  const assetPair = await _getAssetPairById(id);
+  dispatch(setAssetPair(assetPair));
+  return assetPair;
+};
 
 export const getAssetPairs = (params?: {page?: number; page_size?: number}) => async (dispatch: AppDispatch) => {
   const responseData = await _getAssetPairs(params);

--- a/src/pages/Exchange/MainArea/Trade/index.tsx
+++ b/src/pages/Exchange/MainArea/Trade/index.tsx
@@ -6,7 +6,7 @@ import LeavesEmptyState from 'assets/leaves-empty-state.png';
 import EmptyPage from 'components/EmptyPage';
 import OrderBookWebSocket from 'containers/OrderBookWebSocket';
 import TradeWebSocket from 'containers/TradeWebSocket';
-import {getAssetPairs as _getAssetPairs} from 'dispatchers/assetPairs';
+import {getAssetPairById as _getAssetPairById, getAssetPairs as _getAssetPairs} from 'dispatchers/assetPairs';
 import {getAssetPairs} from 'selectors/state';
 import {AppDispatch, SFC} from 'types';
 import {displayErrorToast} from 'utils/toasts';
@@ -36,6 +36,23 @@ const Trade: SFC = ({className}) => {
       }
     })();
   }, [dispatch]);
+
+  useEffect(() => {
+    if (!assetPairId) return;
+
+    const numericId = parseInt(assetPairId, 10);
+    if (isNaN(numericId)) return;
+
+    if (!assetPairs[numericId]) {
+      (async () => {
+        try {
+          await dispatch(_getAssetPairById(numericId));
+        } catch (error) {
+          displayErrorToast('Error fetching asset pair details');
+        }
+      })();
+    }
+  }, [assetPairId, assetPairs, dispatch]);
 
   const renderPageContent = () => {
     if (!!assetPairList.length) {

--- a/src/store/assetPairs.ts
+++ b/src/store/assetPairs.ts
@@ -9,11 +9,14 @@ const assetPairs = createSlice({
   initialState,
   name: ASSET_PAIRS,
   reducers: {
+    setAssetPair: (state: AssetPairs, {payload}: PayloadAction<AssetPair>) => {
+      state[payload.id] = payload;
+    },
     setAssetPairs: (state: AssetPairs, {payload}: PayloadAction<AssetPair[]>) => {
       return payload.reduce((acc: AssetPairs, obj) => ({...acc, [obj.id]: obj}), {});
     },
   },
 });
 
-export const {setAssetPairs} = assetPairs.actions;
+export const {setAssetPair, setAssetPairs} = assetPairs.actions;
 export default assetPairs.reducer;


### PR DESCRIPTION
- Implemented `getAssetPairById` function in `assetPairs.ts` to fetch asset pair details by ID.
- Updated dispatchers to include a new action for fetching asset pair by ID and dispatching it to the store.
- Modified the store to handle setting individual asset pairs with a new reducer.
- Enhanced the Trade component to fetch asset pair details when an ID is provided.